### PR TITLE
Handle reboot question by sending "n"

### DIFF
--- a/tasks/system_rom.yml
+++ b/tasks/system_rom.yml
@@ -17,8 +17,10 @@
  - name: Install firmware
    expect:
      command: "{{ FirmwarePath.stdout }}"
+     timeout: 600
      responses:
-       'Do you want to upgrade the software to a newer version (y/n) ?': 'y'
+       'Do you want to upgrade the software to a newer version.*': 'y'
+       'Do you want to reboot your system now.*': 'n'
 
 # - name: Installing System ROM firmware
 #   script: ../files/firmware_installer.sh --some-arguments "{{ FirmwarePath.stdout }}"


### PR DESCRIPTION
We really need to have an optional handler to do the reboot here, but
obviously this is risky! Ideally this would happen only when the machine
is first kickstarted.
