### PR TITLE
Added logic to handle firmwares without updates

### DIFF
--- a/tasks/disk_controller.yml
+++ b/tasks/disk_controller.yml
@@ -7,20 +7,26 @@
   shell: yum search `hpssacli ctrl all show config | grep -i smart -m 1| awk '{print $3}'` | grep -i `uname -m` | awk '{print $1}'
   register: disk_controller_rpm 
   changed_when: false
+  ignore_errors: yes
 
 - name: Installing firmware RPM for disk controller
   yum: name={{ disk_controller_rpm.stdout }} state=latest
+  when: disk_controller_rpm.rc == 0
 
 - name: Firmware path lookup
   shell: rpm -ql "{{ disk_controller_rpm.stdout }}" | grep '/hpsetup'
   register: FirmwarePackage 
   changed_when: false
+  when: disk_controller_rpm.rc == 0
 
 - name: Store path to hpsetup installer
   set_fact: firmware_installer="{{ FirmwarePackage.stdout }}"
+  when: disk_controller_rpm.rc == 0
 
 - include: firmware_installer.yml
+  when: disk_controller_rpm.rc == 0
 
 - name: Disk controller firmware Cleanup
   yum: name={{ disk_controller_rpm.stdout }} state=absent
+  when: disk_controller_rpm.rc == 0
 

--- a/tasks/disk_drive.yml
+++ b/tasks/disk_drive.yml
@@ -5,20 +5,25 @@
   shell: "yum search `hpssacli ctrl all show config detail | grep Model: | grep HP -m1 | awk '{print $NF}'` | grep -i hp-firmware | awk '{print $1}' | grep `uname  -m`"
   register: disk_drive_rpm 
   changed_when: false
+  ignore_errors: yes
 
 - name: Installing firmware RPM for disk drive
   yum: name={{ disk_drive_rpm.stdout }} state=latest
+  when: disk_drive_rpm.rc == 0
 
 - name: Firmware path lookup
   shell: rpm -ql "{{ disk_drive_rpm.stdout }}" | grep '/hpsetup'
   register: FirmwarePackage 
   changed_when: false
+  when: disk_drive_rpm.rc == 0
 
 - name: Store path to hpsetup installer
   set_fact: firmware_installer="{{ FirmwarePackage.stdout }}"
+  when: disk_drive_rpm.rc == 0
 
 - include: firmware_installer.yml
+  when: disk_drive_rpm.rc == 0
 
 - name: Disk drive firmware Cleanup
   yum: name={{ disk_drive_rpm.stdout }} state=absent
-
+  when: disk_drive_rpm.rc == 0

--- a/tasks/ilo.yml
+++ b/tasks/ilo.yml
@@ -18,18 +18,29 @@
 
  - assert: { that: ilo_version | match("ilo4") }
 
+ - name: Identifying firmware for ILO
+   shell: "yum search hp-firmware-{{ ilo_version }} |grep -i hp-firmware"
+   register: ilo_fw_rpm
+   changed_when: false
+   ignore_errors: yes
+
  - name: Installing firmware RPM
    yum: name=hp-firmware-{{ ilo_version }} state=latest
+   when: ilo_fw_rpm.rc == 0
 
  - name: Firmware path lookup 
    command: rpm -q hp-firmware-"{{ ilo_version }}"
    register: FirmwarePackage
    changed_when: False
+   when: ilo_fw_rpm.rc == 0
 
  - name: Store path to hpsetup installer
    set_fact: firmware_installer="/usr/lib/i386-linux-gnu/{{ FirmwarePackage.stdout | splitext | first }}/hpsetup"
+   when: ilo_fw_rpm.rc == 0
 
  - include: firmware_installer.yml
+   when: ilo_fw_rpm.rc == 0
 
  - name: Firmware RPM cleanup 
    yum: name=hp-firmware-{{ ilo_version }} state=absent
+   when: ilo_fw_rpm.rc == 0

--- a/tasks/intel_network_adapter.yml
+++ b/tasks/intel_network_adapter.yml
@@ -5,20 +5,25 @@
   shell: "yum search hp-firmware-nic-intel | grep `uname -m` | grep -i hp | awk '{ print $1}'"
   register: intel_network_controller_rpm 
   changed_when: false
+  ignore_errors: yes
 
 - name: Installing firmware RPM for Intel Network Controller
   yum: name={{ intel_network_controller_rpm.stdout }} state=latest
+  when: intel_network_controller_rpm.rc == 0
 
 - name: Firmware path lookup
   shell: rpm -ql "{{ intel_network_controller_rpm.stdout }}" | grep '/hpsetup'
   register: FirmwarePackage 
   changed_when: false
+  when: intel_network_controller_rpm.rc == 0
 
 - name: Store path to hpsetup installer
   set_fact: firmware_installer="{{ FirmwarePackage.stdout }}"
+  when: intel_network_controller_rpm.rc == 0
 
 - include: firmware_installer.yml
+  when: intel_network_controller_rpm.rc == 0
 
 - name: Intel Network Controller firmware Cleanup
   yum: name={{ intel_network_controller_rpm.stdout }} state=absent
-
+  when: intel_network_controller_rpm.rc == 0

--- a/tasks/mellanox_network_adapter.yml
+++ b/tasks/mellanox_network_adapter.yml
@@ -1,33 +1,46 @@
 ---
 - assert: { that: "ansible_system_vendor == 'HP'" }
 
+- name: Identifying firmware RPM for Mellanox Network Adapter
+  shell: "yum search hp-firmware-hca-mellanox-vpi-eth-ib |grep hp-firmware-hca-mellanox-vpi-eth-ib"
+  register: mellanox_fw_rpm
+  changed_when: false
+  ignore_errors: yes
+
 - name: Installing firmware RPM for Mellanox Network adapter 
   yum: name=hp-firmware-hca-mellanox-vpi-eth-ib state=latest
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Firmware path lookup
   shell: rpm -ql hp-firmware-hca-mellanox-vpi-eth-ib | grep '/hpsetup'
   register: FirmwarePackage 
   changed_when: false
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Store path to hpsetup installer
   set_fact: firmware_installer="{{ FirmwarePackage.stdout }}"
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Clearing previous log entries
   shell: "> /var/cpq/Component.log"
   ignore_errors: true
   changed_when: false
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Installing firmware
   command: "{{ firmware_installer }} -y "
   ignore_errors: true
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Displaying Firmware installation logs
   shell: "cat /var/cpq/Component.log"
   register: InstallLog
   changed_when: false
+  when: mellanox_fw_rpm.rc == 0
 
 - debug: var=InstallLog.stdout_lines
+  when: mellanox_fw_rpm.rc == 0
 
 - name: Mellanox Network adapter firmware Cleanup
   yum: name=hp-firmware-hca-mellanox-vpi-eth-ib state=absent
-
+  when: mellanox_fw_rpm.rc == 0

--- a/tasks/power_management_controller.yml
+++ b/tasks/power_management_controller.yml
@@ -5,20 +5,26 @@
   shell: yum search `hp-conrep -s | grep  "System Type" | awk '{print $NF}' | tr A-Z a-z` | grep -i hp-firmware-powerpic | awk '{print $1}'
   register: power_management_controller_rpm 
   changed_when: false
+  ignore_errors: yes
 
 - name: Installing firmware RPM for Power Mangement Controller
   yum: name={{ power_management_controller_rpm.stdout }} state=latest
+  when: power_management_controller_rpm.rc == 0
 
 - name: Firmware path lookup
   shell: rpm -ql "{{ power_management_controller_rpm.stdout }}" | grep '/hpsetup'
   register: FirmwarePackage 
   changed_when: false
+  when: power_management_controller_rpm.rc == 0
 
 - name: Store path to hpsetup installer
   set_fact: firmware_installer="{{ FirmwarePackage.stdout }}"
+  when: power_management_controller_rpm.rc == 0
 
 - include: firmware_installer.yml
+  when: power_management_controller_rpm.rc == 0
 
 - name: Power Management Controller firmware Cleanup
   yum: name={{ power_management_controller_rpm.stdout }} state=absent
+  when: power_management_controller_rpm.rc == 0
 

--- a/tasks/system_rom.yml
+++ b/tasks/system_rom.yml
@@ -3,19 +3,29 @@
    shell: hp-conrep -s | grep -i family | awk '{print $NF}' | tr A-Z a-z
    register: systemrom
 
+ - name: Identifying firmware RPM for System ROM
+   shell: "yum search hp-firmware-system-{{ systemrom.stdout }} | grep hp-firmware-system"
+   register: system_rom_fw_rpm
+   changed_when: false
+   ignore_errors: yes
+
  - name: Installing firmware RPM for System ROM
    yum: name=hp-firmware-system-{{ systemrom.stdout }} state=latest
+   when: system_rom_fw_rpm.rc == 0
 
  - name: Firmware path lookup
    command: rpm -q hp-firmware-system-"{{ systemrom.stdout }}" 
    register: FirmwarePackage
    changed_when: False
+   when: system_rom_fw_rpm.rc == 0
 
  - name: Store path to hpsetup installer
    set_fact: firmware_installer="/usr/lib/i386-linux-gnu/{{ FirmwarePackage.stdout | splitext | first }}/hpsetup"
+   when: system_rom_fw_rpm.rc == 0
 
  - include: firmware_installer.yml
+   when: system_rom_fw_rpm.rc == 0
 
  - name: System ROM firmware Cleanup
    yum: name=hp-firmware-system-{{ systemrom.stdout }} state=absent
-
+   when: system_rom_fw_rpm.rc == 0


### PR DESCRIPTION
Some of the firmwares don't yet have updates in the HP repo. This caused
the playbook to fail, since the requested RPMs were missing. I added
logic to check if the RPMs exist. If not, updating that piece of
firmware will be skipped.
