### PR TITLE
check_mode = no

### DIFF
--- a/tasks/ilo.yml
+++ b/tasks/ilo.yml
@@ -9,7 +9,7 @@
    command: lspci -s 01:00.0 -m
    register: ilo_info
    changed_when: False
-   always_run: True
+   check_mode = no
 
    # We need to get the "iLO4" from the above into a varible
    # using the python split fuction on the '"' character and the 2nd from last
@@ -24,7 +24,7 @@
    register: ilo_fw_rpm
    changed_when: False
    ignore_errors: True
-   always_run: True
+   check_mode = no
 
  - name: Installing firmware RPM
    yum: name=hp-firmware-{{ ilo_version }} state=latest
@@ -34,7 +34,7 @@
    command: rpm -q hp-firmware-"{{ ilo_version }}"
    register: FirmwarePackage
    changed_when: False
-   always_run: True
+   check_mode = no
    when: ilo_fw_rpm.rc == 0
 
  - name: Store path to hpsetup installer


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no
instead..
This feature will be removed in version 2.4. Deprecation warnings can
be disabled by setting
deprecation_warnings=False in ansible.cfg.