### PR TITLE
fix hpsetup extract fail under some circumstances

### DIFF
--- a/tasks/firmware_installer.yml
+++ b/tasks/firmware_installer.yml
@@ -10,7 +10,7 @@
   yum: name={{ item | splitext | first }}  state=latest
 
 - name: extract path for hpsetup command
-  shell: "rpm -ql {{ item }}|grep -i hpsetup"
+  shell: "rpm -ql {{ item }}|grep -i 'hpsetup'"
   args:
     warn: False
   register: FirmwarePackage
@@ -19,7 +19,6 @@
 
 - name:  set_fact for firmware_installer path from "{{ item }}" RPM
   set_fact: firmware_installer="{{ FirmwarePackage.stdout | splitext | first }}"
-
 
 - name: Installing firmware from "{{ item }}"  in silent mode
   command: "{{ firmware_installer }}  -s "

--- a/tasks/firmware_installer.yml
+++ b/tasks/firmware_installer.yml
@@ -10,7 +10,7 @@
   yum: name={{ item | splitext | first }}  state=latest
 
 - name: extract path for hpsetup command
-  shell: "rpm -ql {{ item }}|grep /hpsetup"
+  shell: "rpm -ql {{ item }}|grep -i hpsetup"
   args:
     warn: False
   register: FirmwarePackage


### PR DESCRIPTION
Under some circumstances the role cannot found the hpsetup script under the firmware directory:

`TASK [hp-firmware-upgrade : extract path for hpsetup command] ******************
fatal: [hostnameXY]: FAILED! => {"changed": false, "cmd": "rpm -ql hp-firmware-system-p68.i386|grep /hpsetup", "delta": "0:00:00.077839", "end": "2019-02-05 12:04:00.731669", "msg": "non-zero return code", "rc": 1, "start": "2019-02-05 12:04:00.653830", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []} `