### PR TITLE
some fixes

### DIFF
--- a/tasks/ilo.yml
+++ b/tasks/ilo.yml
@@ -22,7 +22,7 @@
  - assert: { that: ilo_version is match("ilo4") }
 
  - name: Identifying firmware for ILO
-   shell: "yum search {{ ilo_version }} |grep -i firmware"
+   shell: "yum list | grep firmware-{{ ilo_version }} | sort -n +1 -2 | tail -1 | awk '{print $NR}'"
    args:
      warn: False
    register: fw_rpm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,39 +12,39 @@
 - include_tasks: ilo.yml
   tags:
     - ilo
-  when: upgrade_ilo_firmware
+  when: upgrade_ilo_firmware|bool
 
 - include_tasks: system_rom.yml
   tags:
    - system-rom
-  when: upgrade_system_rom_firmware
+  when: upgrade_system_rom_firmware|bool
 
 - include_tasks: disk_controller.yml
   tags:
    - disk-controller
-  when: upgrade_disk_controller_firmware
+  when: upgrade_disk_controller_firmware|bool
 
 - include_tasks: disk_drive.yml
   tags:
    - disk-drive
-  when: upgrade_disk_drive_firmware
+  when: upgrade_disk_drive_firmware|bool
 
 - include_tasks: power_management_controller.yml
   tags:
    - power-management-controller
-  when: upgrade_power_management_controller_firmware
+  when: upgrade_power_management_controller_firmware|bool
 
 - include_tasks: intel_network_adapter.yml
   tags:
    - intel-network-adapter
-  when: upgrade_intel_network_adapter_firmware
+  when: upgrade_intel_network_adapter_firmware|bool
 
 - include_tasks: mellanox_network_adapter.yml
   tags:
    - mellanox-network-adapter
-  when: upgrade_mellanox_network_adapter_firmware
+  when: upgrade_mellanox_network_adapter_firmware|bool
 
 - include_tasks: qlogic_network_adapter.yml
   tags:
    - qlogic-network-adapter
-  when: upgrade_qlogic_network_adapter_firmware
+  when: upgrade_qlogic_network_adapter_firmware|bool


### PR DESCRIPTION
This fix removes a little problem with ilo packages. In some HP repos there two different namings for this packages.
- hp-firmware-ilo4 (older packages)
- firmware-ilo4 (newer packages)
With the new filter only the newest packages are used. 

This fix removes some deprecation warnings with bare variables.

`[DEPRECATION WARNING]: evaluating u'upgrade_ilo_firmware' as a bare variable, 
this behaviour will go away and you might need to add |bool to the expression 
in the future. Also see CONDITIONAL_BARE_VARS configuration toggle. This 
feature will be removed in version 2.12. Deprecation warnings can be disabled 
by setting deprecation_warnings=False in ansible.cfg.`