### PR TITLE
Fix travis centos7 url's to point to vault.centos

### DIFF
--- a/tests/epel-centos7/Dockerfile
+++ b/tests/epel-centos7/Dockerfile
@@ -1,7 +1,9 @@
 # Latest version of centos
 FROM centos:centos7
 MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
-RUN yum clean all && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum clean all && \
     yum -y install epel-release && \
     yum -y install python-devel MySQL-python sshpass && \
     yum -y install acl sudo && \


### PR DESCRIPTION
Should fix issue #38

Unashamedly copied from
https://github.com/CSCfi/ansible-role-dhcp-kickstart/pull/36/commits/c398eeba7cda9b900ff0ff26b6da236ac58dbf23 Thanks @matteopozza.