### PR TITLE
Fix hp gen variable syntax

### DIFF
--- a/tasks/prerequisite.yml
+++ b/tasks/prerequisite.yml
@@ -32,7 +32,7 @@
     owner: root 
     group: root 
     mode: '0644'
-  when: hp_gen == "9" and vault_hp_firmware_repository_access is defined
+  when: hp_gen == "gen9" and vault_hp_firmware_repository_access is defined
 
 - name: Template HP YUM fwpp gen10 repository file
   template: 
@@ -41,7 +41,7 @@
     owner: root 
     group: root 
     mode: '0644'
-  when: hp_gen == "10"
+  when: hp_gen == "gen10"
 
 - name: Install requirement packages
   package:

--- a/templates/HP.repo.j2
+++ b/templates/HP.repo.j2
@@ -21,7 +21,7 @@ gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-stk
 
 [spp]
 name=Service Pack for ProLiant
-baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-{{ hp_gen }}/RHEL/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
+baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-{{ hp_gen }}/redhat/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-ServicePackforProLiant

--- a/templates/HP.repo.j2
+++ b/templates/HP.repo.j2
@@ -21,7 +21,7 @@ gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-stk
 
 [spp]
 name=Service Pack for ProLiant
-baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-gen9/RHEL/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
+baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-{{ hp_gen }}/RHEL/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-ServicePackforProLiant

--- a/templates/HPgen10+fwpp.repo.j2
+++ b/templates/HPgen10+fwpp.repo.j2
@@ -1,6 +1,6 @@
 [fwpp]
 name=HP Firmware Pack for ProLiant
-baseurl=https://downloads.linux.hpe.com/SDR/repo/fwpp-gen{{ hp_gen }}/current/
+baseurl=https://downloads.linux.hpe.com/SDR/repo/fwpp-{{ hp_gen }}/current/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-fwpp

--- a/templates/HPgen9fwpp.repo.j2
+++ b/templates/HPgen9fwpp.repo.j2
@@ -1,6 +1,6 @@
 [fwpp]
 name=HP Firmware Pack for ProLiant
-baseurl=https://{{ vault_hp_firmware_repository_access }}downloads.linux.hpe.com/SDR/repo/fwpp-gen{{ hp_gen }}/current/
+baseurl=https://{{ vault_hp_firmware_repository_access }}downloads.linux.hpe.com/SDR/repo/fwpp-{{ hp_gen }}/current/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-fwpp

--- a/tests/templates/HP.repo.j2
+++ b/tests/templates/HP.repo.j2
@@ -21,7 +21,7 @@ gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-stk
 
 [spp]
 name=Service Pack for ProLiant
-baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-gen9/RHEL/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
+baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-{{ hp_gen }}/redhat/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-ServicePackforProLiant


### PR DESCRIPTION
This pull request wants to fix non-functioning repo urls, as HPE repo installation was enabled earlier to this role. This PR also makes repo url for HPE spp repository more generic, by using hp_gen variable that was set earlier in the role.