### PR TITLE
Remove hp scripting tools

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,9 @@ local_firmware_location: files/rpms/
 hp_firmware_allow_reboots: false
 
 requirement_pkgs:
-- {name: ssacli, repo: spp}
-- {name: pciutils, repo: }
+- { name: ssacli, repo: spp }
+- { name: pciutils, repo: }
+- { name: ilorest, repo: ilorest }
 
 use_modern_installer: False
 install_requirements: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ hp_firmware_allow_reboots: false
 
 requirement_pkgs:
 - {name: ssacli, repo: spp}
-- {name: hp-scripting-tools, repo: stk}
 - {name: pciutils, repo: }
 
 use_modern_installer: False

--- a/tests/templates/HP.repo.j2
+++ b/tests/templates/HP.repo.j2
@@ -12,13 +12,6 @@ enabled=1
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-hprest
 
-[stk]
-name=HP scripting tools
-baseurl=https://downloads.linux.hpe.com/repo/stk/rhel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/
-enabled=1
-gpgcheck=0
-gpgkey=file:///etc/pki/rpm-gpg/GPG-KEY-stk
-
 [spp]
 name=Service Pack for ProLiant
 baseurl=https://downloads.linux.hpe.com/SDR/repo/spp-{{ hp_gen }}/redhat/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/current/


### PR DESCRIPTION
https://downloads.linux.hpe.com/repo/stk/rhel/ support ends for rhel8, which is end-of-life already.

